### PR TITLE
Add Jest framework with sample test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts']
+}

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges Tailwind class names', () => {
+    expect(cn('text-sm', 'text-lg')).toBe('text-lg')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
         "autoprefixer": "^10.4.17",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.0",
+        "@types/jest": "^29.5.0"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "^14.2.0",
@@ -23,6 +24,9 @@
     "postcss": "^8.4.38",
     "autoprefixer": "^10.4.17",
     "@types/react": "^18.2.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- setup Jest via ts-jest preset
- add test for `cn` utility
- wire `test` script in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d6351fb88331ad46b50a95959813